### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/riccardogelleni/803379f8-1e35-4939-ba4a-0a80bcafafd9/37f3f148-c7d8-49fe-bbe7-d728efb24093/_apis/work/boardbadge/798ff9cc-a506-431c-ba30-5ebfc068aa7b)](https://dev.azure.com/riccardogelleni/803379f8-1e35-4939-ba4a-0a80bcafafd9/_boards/board/t/37f3f148-c7d8-49fe-bbe7-d728efb24093/Microsoft.RequirementCategory)
 # IntesaTest


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.